### PR TITLE
Use fully qualified namespace

### DIFF
--- a/app/boilerplates/simple/tests/admin/test-class-app.php
+++ b/app/boilerplates/simple/tests/admin/test-class-app.php
@@ -13,14 +13,14 @@ final class App_Test extends WP_UnitTestCase {
 	/**
 	 * Test __construct
 	 *
-	 * @covers <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Admin\App::__construct
+	 * @covers \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Admin\App::__construct
 	 */
 	public function test_construct() {
 		$installed_dir = '/var/installed/dir';
 		$installed_url = '/var/installed/url';
 		$version       = 1.0;
 
-		$app = new <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Admin\App( $installed_dir, $installed_url, $version );
+		$app = new \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Admin\App( $installed_dir, $installed_url, $version );
 
 		$this->assertEquals( $installed_dir, $app->installed_dir );
 		$this->assertEquals( $installed_url, $app->installed_url );

--- a/app/boilerplates/simple/tests/test-class-plugin.php
+++ b/app/boilerplates/simple/tests/test-class-plugin.php
@@ -17,6 +17,7 @@ final class Plugin_Test extends WP_UnitTestCase {
 	 */
 	public function test_onload() {
 		$instance = new stdClass();
+
 		$plugin   = new \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
 		$result   = $plugin->onload( $instance );
 

--- a/app/boilerplates/simple/tests/test-class-plugin.php
+++ b/app/boilerplates/simple/tests/test-class-plugin.php
@@ -13,11 +13,11 @@ final class Plugin_Test extends WP_UnitTestCase {
 	/**
 	 * Test onload
 	 *
-	 * @covers <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::onload
+	 * @covers \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::onload
 	 */
 	public function test_onload() {
 		$instance = new stdClass();
-		$plugin   = new <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
+		$plugin   = new \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
 		$result   = $plugin->onload( $instance );
 
 		$this->assertNull( $result );
@@ -26,12 +26,12 @@ final class Plugin_Test extends WP_UnitTestCase {
 	/**
 	 * Test init
 	 *
-	 * @covers <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::init
+	 * @covers \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::init
 	 */
 	public function test_init() {
 		global $wp_actions;
 
-		$plugin = new <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
+		$plugin = new \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
 		$result = $plugin->init();
 
 		$this->assertTrue( isset( $wp_actions['<%= US_SLUG %>_before_init'] ) );
@@ -43,10 +43,10 @@ final class Plugin_Test extends WP_UnitTestCase {
 	/**
 	 * Test authenticated_init when user is not logged in
 	 *
-	 * @covers <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::authenticated_init
+	 * @covers \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::authenticated_init
 	 */
 	public function test_authenticated_init_when_user_is_not_logged_in() {
-		$plugin             = new <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
+		$plugin             = new \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
 		$authenticated_init = $plugin->authenticated_init();
 
 		$this->assertFalse( isset( $plugin->admin ) );
@@ -56,13 +56,13 @@ final class Plugin_Test extends WP_UnitTestCase {
 	/**
 	 * Test authenticated_init when user is logged in
 	 *
-	 * @covers <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::authenticated_init
+	 * @covers \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin::authenticated_init
 	 */
 	public function test_authenticated_init_when_user_is_logged_in() {
 		$user_id = $this->factory->user->create();
 		wp_set_current_user( $user_id );
 
-		$plugin             = new <%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
+		$plugin             = new \<%= PRIMARY_NAMESPACE %>\<%= SECONDARY_NAMESPACE %>\Plugin();
 		$authenticated_init = $plugin->authenticated_init();
 
 		$this->assertTrue( isset( $plugin->admin ) );

--- a/wordpress-development-toolkit.php
+++ b/wordpress-development-toolkit.php
@@ -6,7 +6,7 @@
  * @author      David Ryan - WordPress Phoenix
  * @license     GNU GPL v2.0+
  * @link        https://github.com/wordpress-phoenix
- * @version     3.2.0
+ * @version     3.2.1
  *
  * Built using WP PHX Plugin Generator v1.1.0 on Tuesday 23rd of January 2018 07:33:12 AM
  * @link https://github.com/WordPress-Phoenix/wordpress-development-toolkit


### PR DESCRIPTION
## Description
- Use fully qualify namespace on unit test

## Testing

Same as https://github.com/WordPress-Phoenix/wordpress-development-toolkit/pull/10

## Screenshot
<img width="868" alt="Screen Shot 2019-05-02 at 10 47 54 AM" src="https://user-images.githubusercontent.com/2894340/57084148-c58aa400-6cc7-11e9-8ff8-59f9a157f629.png">

<img width="716" alt="Screen Shot 2019-05-02 at 10 42 37 AM" src="https://user-images.githubusercontent.com/2894340/57083917-501ed380-6cc7-11e9-962a-ac5486d42e13.png">

<img width="864" alt="Screen Shot 2019-05-02 at 10 43 06 AM" src="https://user-images.githubusercontent.com/2894340/57083918-501ed380-6cc7-11e9-9b70-10d4fa8757c0.png">
